### PR TITLE
Fix duplicate heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # strip-accents
 Removes the accents/diacritics from a string, converting them to their corresponding non-accented ASCII characters.
 
-# strip-accents
 
 > Strip [Unicode/UTF-8-character](https://www.utf8-chartable.de/) from a string
 


### PR DESCRIPTION
## Summary
- remove repeated `strip-accents` heading in the README

## Testing
- `npm test` *(fails: Error: no test specified)*